### PR TITLE
Float Pragmas

### DIFF
--- a/src/Addresses.sol
+++ b/src/Addresses.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 import {Test} from "@forge-std/Test.sol";
 import {IAddresses} from "./IAddresses.sol";

--- a/src/IAddresses.sol
+++ b/src/IAddresses.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 interface IAddresses {
 

--- a/src/TestProposals.sol
+++ b/src/TestProposals.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 import {console} from "@forge-std/console.sol";
 import {Test} from "@forge-std/Test.sol";

--- a/src/example/ExampleAddresses.sol
+++ b/src/example/ExampleAddresses.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 import {Addresses} from "./../Addresses.sol";
 

--- a/src/example/vip15.sol
+++ b/src/example/vip15.sol
@@ -1,5 +1,5 @@
 ///SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 import {ITimelockController} from "@proposal-types/ITimelockController.sol";
 import {TimelockProposal} from "@proposal-types/TimelockProposal.sol";

--- a/src/proposalTypes/IProposal.sol
+++ b/src/proposalTypes/IProposal.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 import {IAddresses} from "./../IAddresses.sol";
 

--- a/src/proposalTypes/ITimelockController.sol
+++ b/src/proposalTypes/ITimelockController.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.6.0) (governance/TimelockController.sol)
 
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Contract module which acts as a timelocked controller. When set as the

--- a/src/proposalTypes/MultisigProposal.sol
+++ b/src/proposalTypes/MultisigProposal.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 import {Proposal} from "./Proposal.sol";
 

--- a/src/proposalTypes/Proposal.sol
+++ b/src/proposalTypes/Proposal.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 import {Test} from "@forge-std/Test.sol";
 import {IProposal} from "./IProposal.sol";

--- a/src/proposalTypes/TimelockProposal.sol
+++ b/src/proposalTypes/TimelockProposal.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.8.13;
+pragma solidity ^0.8.0;
 
 import {console} from "@forge-std/console.sol";
 


### PR DESCRIPTION
This PR allows the solidity version to match any solidity version from 0.8.0 up until but not including 0.9.0.